### PR TITLE
Fix `parent(query, context)` method

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -105,7 +105,7 @@ export default class {
 
     parent(query, context) {
         const data = '[' + this.mAttr + '=' + query + ']';
-        let parent = context;
+        let parent = context.parentNode;
 
         while (parent && parent !== document) {
             if (parent.matches(data)) {


### PR DESCRIPTION
Begin query on context's immediate parent node instead of context itself (false positive)